### PR TITLE
Improve macro templating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "rust_html"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "axum-core",
  "html-escape",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "rust_html_macros"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "litrs",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_html"
 edition = "2021"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Sigve Røkenes <me@evgiz.net>"]
 license = "MIT"
 readme = "README.md"
@@ -26,7 +26,7 @@ name = "rust_html"
 
 [dependencies]
 html-escape = "0.2.13"
-rust_html_macros = { path = "./rust_html_macros", version = "1.1.1" }
+rust_html_macros = { path = "./rust_html_macros", version = "1.1.2" }
 axum-core = { version = "0.4", optional = true }
 http = { version = "1", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The library has only 5 exported functions/types:
 - `Unescaped`: string wrapper for inserting unescaped values
 - `TemplateGroup`: wrapper to insert a `Vec<Template>`
 
+> [!NOTE]  
+> The `Template` struct itself does not implement the `Display` trait.
+> To print or return the HTML value as a `String` you can use `String::from(my_template)`
+> or just `my_template.into()` where applicable.
+
 ### The `rhtml!` macro
 
 The `rhtml!` macro accepts a single string literal as input, typically
@@ -72,13 +77,8 @@ The macro returns a `Template` struct that ensures injection safety when
 reusing template within templates.
 
 Inside the macro string you can inject anything that implements either the
-`std::fmt::Display` or `::Render` trait by using brackets `{}`.
-You can escape brackets by using two of them in a row (`{{` or `}}`).
-
-> [!NOTE]  
-> The `Template` struct itself does not implement the `Display` trait.
-> To print or return the HTML value as a `String` you can use `String::from(my_template)`
-> or just `my_template.into()` where applicable.
+`std::fmt::Display` or `Render` trait by using brackets `{}`.
+You can escape brackets inside the HTML by using two of them in a row (`{{` or `}}`).
 
 ### Example - Reusable Components
 
@@ -153,6 +153,16 @@ fn main() {
     println!("{}", String::from(page));
     // Output is '<div>Bob is an adult</div>'
 }
+```
+
+To prevent ambiguity you must only use `{` and `}` for opening/closing scopes
+in the injected rust code - not inside literals or comments.
+The following is therefore not valid:
+
+```rust
+rhtml! { r#"{ if true { "}" } else { "" } }"# };
+//                       ^
+//                       Bracket not allowed
 ```
 
 ### Structs as reusable components

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ standard HTML syntax directly and keep the templates next to your other Rust cod
 
 ## Installation
 
-Inside your project directory, add using cargo:
+Install from [crates.io](https://crates.io/crates/rust_html) using cargo:
 
 ```bash
 cargo add rust_html

--- a/rust_html_macros/Cargo.toml
+++ b/rust_html_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_html_macros"
 edition = "2021"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Sigve Røkenes <me@evgiz.net>"]
 license = "MIT"
 readme = "../README.md"

--- a/rust_html_macros/src/util.rs
+++ b/rust_html_macros/src/util.rs
@@ -81,7 +81,9 @@ pub fn wrap_rust_compile_error(
 ) -> TokenStream {
     let mut html_short = false;
     let html_info_max = 20;
-    let html_info = if html_code.len() <= html_info_max {
+    let html_info = if html_code.is_empty() {
+        ""
+    } else if html_code.len() <= html_info_max {
         &html_code[..html_code.len() - 1]
     } else {
         html_short = true;
@@ -90,7 +92,9 @@ pub fn wrap_rust_compile_error(
 
     let mut rust_short = false;
     let rust_info_max = 15;
-    let rust_info = if rust_code.len() <= rust_info_max {
+    let rust_info = if rust_code.is_empty() {
+        ""
+    } else if rust_code.len() <= rust_info_max {
         rust_code
     } else {
         rust_short = true;

--- a/rust_html_tests/src/lib.rs
+++ b/rust_html_tests/src/lib.rs
@@ -199,12 +199,22 @@ mod test {
 
     #[test]
     pub fn test_conditional() {
-        test_eq(rhtml! {"{ if true {1} else {2}}"}, "1");
+        test_eq(rhtml! {"{ if true {1} else {2} }"}, "1");
     }
 
     #[test]
     pub fn test_conditional_str() {
         test_eq(rhtml! {r#"{ if true { "hello" } else {"world"}}"#}, "hello");
+    }
+
+    #[test]
+    pub fn test_conditional_template_or_str() {
+        let template = || rhtml! { "hello" };
+        let string = "world".to_string();
+        test_eq(
+            rhtml! {r#"{ if true { template() } else { string.into() } }"#},
+            "hello",
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Improves macro generation to use vector concatenation in favor of replace
- Implements `From<T> for Template` for all `T: std::fmt::Display`
- Updated readme