### PR TITLE
Add HTML line trimming to parse <tr> rows correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "rust_html"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "axum",
  "axum-core",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "rust_html_macros"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "html5ever",
  "litrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_html"
 edition = "2021"
-version = "1.1.4"
+version = "1.1.5"
 authors = ["Sigve Røkenes <me@evgiz.net>"]
 license = "MIT"
 readme = "README.md"
@@ -26,7 +26,7 @@ name = "rust_html"
 
 [dependencies]
 html-escape = "0.2.13"
-rust_html_macros = { path = "./rust_html_macros", version = "1.1.3" }
+rust_html_macros = { path = "./rust_html_macros", version = "1.1.4" }
 axum-core = { version = "0.4", optional = true }
 http = { version = "1", optional = true }
 

--- a/rust_html_macros/Cargo.toml
+++ b/rust_html_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_html_macros"
 edition = "2021"
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Sigve Røkenes <me@evgiz.net>"]
 license = "MIT"
 readme = "../README.md"

--- a/rust_html_macros/src/lib.rs
+++ b/rust_html_macros/src/lib.rs
@@ -110,7 +110,7 @@ fn expand(input: TokenStream) -> TokenStream {
     };
 
     // Compile time HTML syntax check
-    let html_for_validate = html_parts.join("");
+    let html_for_validate = trim_whitespace_per_line(&html_parts.join(""));
     if let Err(error) = compile_check_html(&html_for_validate) {
         return error;
     }

--- a/rust_html_macros/src/util.rs
+++ b/rust_html_macros/src/util.rs
@@ -129,3 +129,23 @@ pub fn compile_error(error: &str) -> TokenStream {
     .into_iter()
     .collect()
 }
+
+/// Removes empty lines and whitespace surroinding each line
+/// Necessary for certain quirks of the html5ever parser
+///
+/// E.g <tr> rows must be trimmed this way
+/// since whitespace is parsed as text tokens.
+pub fn trim_whitespace_per_line(html: &str) -> String {
+    html.split('\n')
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_string()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 pub use rust_html_macros::rhtml;
 
 pub mod integration;


### PR DESCRIPTION
Adds per-line trimming before HTML syntax check.

Necessary to support `<tr>` tags in nicely formatted `rhtml!` macros, since html5ever treats all whitespace as text tokens.